### PR TITLE
chore: regenerate npm lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -536,26 +536,26 @@
             "license": "MIT"
         },
         "node_modules/@dxup/nuxt": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.6.tgz",
-            "integrity": "sha512-uZjAFoocWtWHr7YP9jm6FqwI8kjX2QN9bjcncoZt0GS+zExIAP3Ewv6EqEUvVP7w9pjZE+T19QxLHeoacN/MNg==",
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.10.tgz",
+            "integrity": "sha512-54Vehb7LmR7qYpC6KFwjDTSm6CB1CayBu+JXdHrPLrIjjr5xAgb43jvgOU+mnB+tsRh414fSsEy0QjBMKILQ8g==",
             "license": "MIT",
             "dependencies": {
                 "@dxup/unimport": "^0.1.2",
-                "@nuxt/kit": "^4.5.1",
-                "@vue/compiler-dom": "^3.5.40",
+                "@nuxt/kit": "^4.5.2",
+                "@vue/compiler-dom": "^3.5.41",
                 "chokidar": "^5.0.0",
                 "knitwork": "^1.3.0",
-                "magic-string": "^1.1.0",
+                "magic-string": "^1.2.2",
                 "pathe": "^2.0.3",
                 "tinyglobby": "^0.2.17",
                 "unplugin": "^3.3.0"
             }
         },
         "node_modules/@dxup/nuxt/node_modules/magic-string": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
-            "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+            "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -568,20 +568,20 @@
             "license": "MIT"
         },
         "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -589,9 +589,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -636,9 +636,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -652,9 +652,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
             "cpu": [
                 "arm"
             ],
@@ -668,9 +668,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
             "cpu": [
                 "arm64"
             ],
@@ -684,9 +684,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
             "cpu": [
                 "x64"
             ],
@@ -700,9 +700,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
             "cpu": [
                 "arm64"
             ],
@@ -716,9 +716,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
             "cpu": [
                 "x64"
             ],
@@ -732,9 +732,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
             "cpu": [
                 "arm64"
             ],
@@ -748,9 +748,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
             "cpu": [
                 "x64"
             ],
@@ -764,9 +764,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
             "cpu": [
                 "arm"
             ],
@@ -780,9 +780,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
             "cpu": [
                 "arm64"
             ],
@@ -796,9 +796,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
             "cpu": [
                 "ia32"
             ],
@@ -812,9 +812,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
             "cpu": [
                 "loong64"
             ],
@@ -828,9 +828,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
             "cpu": [
                 "mips64el"
             ],
@@ -844,9 +844,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -860,9 +860,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
             "cpu": [
                 "riscv64"
             ],
@@ -876,9 +876,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
             "cpu": [
                 "s390x"
             ],
@@ -892,9 +892,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
             "cpu": [
                 "x64"
             ],
@@ -908,9 +908,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
             "cpu": [
                 "arm64"
             ],
@@ -924,9 +924,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
             "cpu": [
                 "x64"
             ],
@@ -940,9 +940,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
             "cpu": [
                 "arm64"
             ],
@@ -956,9 +956,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
             "cpu": [
                 "x64"
             ],
@@ -972,9 +972,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
             "cpu": [
                 "arm64"
             ],
@@ -988,9 +988,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
             "cpu": [
                 "x64"
             ],
@@ -1004,9 +1004,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1020,9 +1020,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
             "cpu": [
                 "ia32"
             ],
@@ -1036,9 +1036,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
             "cpu": [
                 "x64"
             ],
@@ -1052,9 +1052,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -1196,13 +1196,6 @@
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
-        },
-        "node_modules/@eslint/css-tree/node_modules/mdn-data": {
-            "version": "2.34.0",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.34.0.tgz",
-            "integrity": "sha512-OgIlLv0NxJKVW4GTSAoEgpRGd4F2XCqGinK0MsMlBCCS/Zcm2/LsbercNWNA7PeMMcjl75NnI97eqyo7zkdxWA==",
-            "dev": true,
-            "license": "CC0-1.0"
         },
         "node_modules/@eslint/js": {
             "version": "10.0.1",
@@ -1442,9 +1435,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -1564,22 +1557,44 @@
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
+        "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+            "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^22.20 || ^24.12 || >=25"
+            }
+        },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+            "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@tybys/wasm-util": "^0.10.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
             },
             "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
+                "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+                "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
             }
         },
         "node_modules/@nodable/entities": {
@@ -1794,38 +1809,6 @@
                 }
             }
         },
-        "node_modules/@nuxt/content/node_modules/db0": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/db0/-/db0-0.4.1.tgz",
-            "integrity": "sha512-6RBY/bSn42UrqATwsiULj2uYFyEykB3XeA/NLIVQeHNXlYV6D4Idxx3/aa6k5Y45Dwzx7sygeLotnqHWSeURYA==",
-            "license": "MIT"
-        },
-        "node_modules/@nuxt/content/node_modules/unctx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.1.tgz",
-            "integrity": "sha512-5RAt2etv7g362RXyd33R82gm9u/kbtQlpoaOs9Bgm4E32GRMJ0xjbZyvdxUTmiuHk3V1IQb1aUNrp5IWY+JaWw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "magic-string": ">=0.30.21",
-                "oxc-parser": ">=0.140.0",
-                "rolldown": "^1.1.5",
-                "unplugin": "^3.3.0"
-            },
-            "peerDependenciesMeta": {
-                "magic-string": {
-                    "optional": true
-                },
-                "oxc-parser": {
-                    "optional": true
-                },
-                "rolldown": {
-                    "optional": true
-                },
-                "unplugin": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@nuxt/devalue": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",
@@ -1833,13 +1816,13 @@
             "license": "MIT"
         },
         "node_modules/@nuxt/devtools": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-3.4.1.tgz",
-            "integrity": "sha512-20zZs6k/zAdi+PM7s1BwxE3hanZ+R1OGi5DWCKPyzSnhUUeeNebvWNgec7Rwnx6iKLkJfK4WFIZ+FL2QurG/ZQ==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-3.4.2.tgz",
+            "integrity": "sha512-Nidg0/zB710cyK89ltTkv66hMfPlIPlKA+Yb67bIrAkNm5PoTwQ1goHdFWHIAGZ9nTadcVTzATwMwa56nvl/Wg==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/devtools-kit": "3.4.1",
-                "@nuxt/devtools-wizard": "3.4.1",
+                "@nuxt/devtools-kit": "3.4.2",
+                "@nuxt/devtools-wizard": "3.4.2",
                 "@nuxt/kit": "^4.5.1",
                 "@vue/devtools-core": "^8.2.1",
                 "@vue/devtools-kit": "^8.2.1",
@@ -1886,9 +1869,9 @@
             }
         },
         "node_modules/@nuxt/devtools-kit": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.1.tgz",
-            "integrity": "sha512-6ltPm2yUW8GvDdf3VJna7+flLi+ej7xRfSr+S4ovevKt/CuPf9EqYOn1jW7Kw/U1MXt/71zkn+/O2vu3G6O9Hg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.2.tgz",
+            "integrity": "sha512-TPPbmH9xrExagYxfCe6JgtbHmgchfgDdA656Yws18rn8I/oCvB+gcw3kTWBBp2sC9ipZPXsgbsW/yZnVnGNBiA==",
             "license": "MIT",
             "dependencies": {
                 "@nuxt/kit": "^4.5.1",
@@ -1899,9 +1882,9 @@
             }
         },
         "node_modules/@nuxt/devtools-wizard": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.4.1.tgz",
-            "integrity": "sha512-taGeuTnkHsZVjgD9r6NXvvHaBzB2j4mCgOmlmkz3ntsqgh1SJfmsD11Tmtl7FVAxJS8Wuvuzgt0GyTlADBW9Wg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.4.2.tgz",
+            "integrity": "sha512-U2G8fw7KW1rdECyJDho5N14z8hSllpTk430KG1QPLjrv5w3pDksZ+YcpITd0u762Vw3gq3Arpg65Bk6U4ua6aQ==",
             "license": "MIT",
             "dependencies": {
                 "@clack/prompts": "^1.7.0",
@@ -2067,32 +2050,6 @@
                 "node": ">=18.12.0"
             }
         },
-        "node_modules/@nuxt/kit/node_modules/unctx": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "magic-string": ">=0.30.21",
-                "oxc-parser": ">=0.140.0",
-                "rolldown": "^1.1.5",
-                "unplugin": "^3.3.0"
-            },
-            "peerDependenciesMeta": {
-                "magic-string": {
-                    "optional": true
-                },
-                "oxc-parser": {
-                    "optional": true
-                },
-                "rolldown": {
-                    "optional": true
-                },
-                "unplugin": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@nuxt/nitro-server": {
             "version": "4.5.2",
             "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.5.2.tgz",
@@ -2161,32 +2118,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@nuxt/nitro-server/node_modules/unctx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.1.tgz",
-            "integrity": "sha512-5RAt2etv7g362RXyd33R82gm9u/kbtQlpoaOs9Bgm4E32GRMJ0xjbZyvdxUTmiuHk3V1IQb1aUNrp5IWY+JaWw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "magic-string": ">=0.30.21",
-                "oxc-parser": ">=0.140.0",
-                "rolldown": "^1.1.5",
-                "unplugin": "^3.3.0"
-            },
-            "peerDependenciesMeta": {
-                "magic-string": {
-                    "optional": true
-                },
-                "oxc-parser": {
-                    "optional": true
-                },
-                "rolldown": {
-                    "optional": true
-                },
-                "unplugin": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@nuxt/schema": {
             "version": "4.5.2",
             "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.5.2.tgz",
@@ -2205,16 +2136,15 @@
             }
         },
         "node_modules/@nuxt/telemetry": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.8.0.tgz",
-            "integrity": "sha512-zAwXY24KYvpLTmiV+osagd2EHkfs5IF+7oDZYTQoit5r0kPlwaCNlzHp5I/wUAWT4LBw6lG8gZ6bWidAdv/erQ==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.9.1.tgz",
+            "integrity": "sha512-WYQs6GvebU278YXhbGlLA8pUO3ox+juHAiKCB3SEH0lq2PDRwX465tHRtpVIqsHv+lGK/n99FC7qqyBt9+p3oQ==",
             "license": "MIT",
             "dependencies": {
-                "citty": "^0.2.1",
+                "citty": "^0.2.2",
                 "consola": "^3.4.2",
-                "ofetch": "^2.0.0-alpha.3",
-                "rc9": "^3.0.0",
-                "std-env": "^4.0.0"
+                "rc9": "^3.0.1",
+                "std-env": "^4.2.0"
             },
             "bin": {
                 "nuxt-telemetry": "bin/nuxt-telemetry.mjs"
@@ -2225,12 +2155,6 @@
             "peerDependencies": {
                 "@nuxt/kit": ">=3.0.0"
             }
-        },
-        "node_modules/@nuxt/telemetry/node_modules/ofetch": {
-            "version": "2.0.0-alpha.3",
-            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
-            "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
-            "license": "MIT"
         },
         "node_modules/@nuxt/vite-builder": {
             "version": "4.5.2",
@@ -2392,6 +2316,33 @@
                 }
             }
         },
+        "node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.139.0.tgz",
+            "integrity": "sha512-rNU0pO+/CVPC2qZ+xtX5R2cOje9Q75q3UkfgwUCPlplqxMv6Iffd5tMPGVMCLGnPINxPlmi0WPsW94HltbYvfQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@parcel/watcher-wasm": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.6.0.tgz",
@@ -2484,10 +2435,26 @@
             "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
             "license": "MIT"
         },
+        "node_modules/@rolldown/binding-android-arm-eabi": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+            "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-            "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+            "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
             "cpu": [
                 "arm64"
             ],
@@ -2501,9 +2468,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-            "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+            "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
             "cpu": [
                 "arm64"
             ],
@@ -2517,9 +2484,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-            "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+            "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
             "cpu": [
                 "x64"
             ],
@@ -2533,9 +2500,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-            "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+            "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
             "cpu": [
                 "x64"
             ],
@@ -2549,9 +2516,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-            "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+            "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
             "cpu": [
                 "arm"
             ],
@@ -2565,11 +2532,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-            "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+            "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2581,11 +2551,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-            "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+            "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2597,11 +2570,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-            "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+            "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2613,11 +2589,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-            "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+            "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2629,11 +2608,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-            "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+            "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2645,11 +2627,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-            "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+            "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2661,9 +2646,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-            "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+            "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
             "cpu": [
                 "arm64"
             ],
@@ -2677,9 +2662,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-            "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+            "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
             "cpu": [
                 "arm64"
             ],
@@ -2693,9 +2678,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-            "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+            "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
             "cpu": [
                 "x64"
             ],
@@ -2889,9 +2874,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+            "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
             "cpu": [
                 "arm"
             ],
@@ -2902,9 +2887,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+            "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2915,9 +2900,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+            "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2928,9 +2913,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+            "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
             "cpu": [
                 "x64"
             ],
@@ -2941,9 +2926,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+            "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
             "cpu": [
                 "arm64"
             ],
@@ -2954,9 +2939,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+            "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
             "cpu": [
                 "x64"
             ],
@@ -2967,11 +2952,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+            "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2980,11 +2968,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+            "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2993,11 +2984,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+            "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3006,11 +3000,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+            "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3019,11 +3016,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+            "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
             "cpu": [
                 "loong64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3032,11 +3032,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+            "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
             "cpu": [
                 "loong64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3045,11 +3048,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+            "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3058,11 +3064,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+            "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3071,11 +3080,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+            "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3084,11 +3096,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+            "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3097,11 +3112,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+            "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3110,11 +3128,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+            "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3123,11 +3144,14 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+            "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3136,9 +3160,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+            "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
             "cpu": [
                 "x64"
             ],
@@ -3149,9 +3173,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+            "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
             "cpu": [
                 "arm64"
             ],
@@ -3162,9 +3186,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+            "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
             "cpu": [
                 "arm64"
             ],
@@ -3175,9 +3199,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+            "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
             "cpu": [
                 "ia32"
             ],
@@ -3188,9 +3212,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+            "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
             "cpu": [
                 "x64"
             ],
@@ -3201,9 +3225,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+            "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
             "cpu": [
                 "x64"
             ],
@@ -3385,9 +3409,9 @@
             "license": "MIT"
         },
         "node_modules/@speed-highlight/core": {
-            "version": "1.2.23",
-            "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.23.tgz",
-            "integrity": "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==",
+            "version": "1.2.24",
+            "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+            "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
             "license": "CC0-1.0"
         },
         "node_modules/@sqlite.org/sqlite-wasm": {
@@ -3554,6 +3578,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3569,6 +3596,9 @@
             "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3586,6 +3616,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3601,6 +3634,9 @@
             "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3639,66 +3675,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-            "version": "2.8.1",
-            "inBundle": true,
-            "license": "0BSD",
-            "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.3",
@@ -3809,13 +3785,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.4.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-            "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+            "version": "26.5.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+            "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~8.3.0"
+                "undici-types": "~8.9.0"
             }
         },
         "node_modules/@types/parse-path": {
@@ -4470,6 +4446,40 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
             "version": "1.12.2",
             "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -4601,9 +4611,9 @@
             }
         },
         "node_modules/@vue-macros/common": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.3.tgz",
-            "integrity": "sha512-pphnexn8CDKugcA4TYSKlg1XanBYPbILST+eZK9ZGqG8sVbNR5L0kXEpRqs8+iSznosHt/Jo2k1FGl0tnWIpyg==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.4.tgz",
+            "integrity": "sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==",
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-sfc": "^3.5.22",
@@ -4728,12 +4738,12 @@
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.5.tgz",
-            "integrity": "sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
+            "integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^8.1.5"
+                "@vue/devtools-kit": "^8.2.1"
             }
         },
         "node_modules/@vue/devtools-core": {
@@ -4777,9 +4787,9 @@
             "license": "MIT"
         },
         "node_modules/@vue/language-core": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
-            "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.11.tgz",
+            "integrity": "sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==",
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.28",
@@ -6071,12 +6081,17 @@
             }
         },
         "node_modules/crossws": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
-            "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+            "version": "0.4.12",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.12.tgz",
+            "integrity": "sha512-aypfsr6t0uNvkqaZc6zvBfXzC6pLI0/sIulpkV6RwCVtZqG5ebBzv4weImKK0VNCj91Wl9F5j7p5WU4MNrybng==",
             "license": "MIT",
-            "dependencies": {
-                "uncrypto": "^0.1.3"
+            "peerDependencies": {
+                "srvx": ">=0.11.5"
+            },
+            "peerDependenciesMeta": {
+                "srvx": {
+                    "optional": true
+                }
             }
         },
         "node_modules/css-select": {
@@ -6107,6 +6122,12 @@
             "engines": {
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
             }
+        },
+        "node_modules/css-tree/node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "license": "CC0-1.0"
         },
         "node_modules/css-what": {
             "version": "7.0.0",
@@ -6247,38 +6268,10 @@
             "license": "MIT"
         },
         "node_modules/db0": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
-            "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@electric-sql/pglite": "*",
-                "@libsql/client": "*",
-                "better-sqlite3": "*",
-                "drizzle-orm": "*",
-                "mysql2": "*",
-                "sqlite3": "*"
-            },
-            "peerDependenciesMeta": {
-                "@electric-sql/pglite": {
-                    "optional": true
-                },
-                "@libsql/client": {
-                    "optional": true
-                },
-                "better-sqlite3": {
-                    "optional": true
-                },
-                "drizzle-orm": {
-                    "optional": true
-                },
-                "mysql2": {
-                    "optional": true
-                },
-                "sqlite3": {
-                    "optional": true
-                }
-            }
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/db0/-/db0-0.4.1.tgz",
+            "integrity": "sha512-6RBY/bSn42UrqATwsiULj2uYFyEykB3XeA/NLIVQeHNXlYV6D4Idxx3/aa6k5Y45Dwzx7sygeLotnqHWSeURYA==",
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -6504,21 +6497,6 @@
                     "optional": true
                 },
                 "cac": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/devframe/node_modules/crossws": {
-            "version": "0.4.12",
-            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.12.tgz",
-            "integrity": "sha512-aypfsr6t0uNvkqaZc6zvBfXzC6pLI0/sIulpkV6RwCVtZqG5ebBzv4weImKK0VNCj91Wl9F5j7p5WU4MNrybng==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "srvx": ">=0.11.5"
-            },
-            "peerDependenciesMeta": {
-                "srvx": {
                     "optional": true
                 }
             }
@@ -6779,9 +6757,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -6855,9 +6833,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -6867,32 +6845,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.28.1",
-                "@esbuild/android-arm": "0.28.1",
-                "@esbuild/android-arm64": "0.28.1",
-                "@esbuild/android-x64": "0.28.1",
-                "@esbuild/darwin-arm64": "0.28.1",
-                "@esbuild/darwin-x64": "0.28.1",
-                "@esbuild/freebsd-arm64": "0.28.1",
-                "@esbuild/freebsd-x64": "0.28.1",
-                "@esbuild/linux-arm": "0.28.1",
-                "@esbuild/linux-arm64": "0.28.1",
-                "@esbuild/linux-ia32": "0.28.1",
-                "@esbuild/linux-loong64": "0.28.1",
-                "@esbuild/linux-mips64el": "0.28.1",
-                "@esbuild/linux-ppc64": "0.28.1",
-                "@esbuild/linux-riscv64": "0.28.1",
-                "@esbuild/linux-s390x": "0.28.1",
-                "@esbuild/linux-x64": "0.28.1",
-                "@esbuild/netbsd-arm64": "0.28.1",
-                "@esbuild/netbsd-x64": "0.28.1",
-                "@esbuild/openbsd-arm64": "0.28.1",
-                "@esbuild/openbsd-x64": "0.28.1",
-                "@esbuild/openharmony-arm64": "0.28.1",
-                "@esbuild/sunos-x64": "0.28.1",
-                "@esbuild/win32-arm64": "0.28.1",
-                "@esbuild/win32-ia32": "0.28.1",
-                "@esbuild/win32-x64": "0.28.1"
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
             }
         },
         "node_modules/escalade": {
@@ -7287,9 +7265,9 @@
             }
         },
         "node_modules/eslint-plugin-vue": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
-            "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
+            "version": "10.11.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.11.0.tgz",
+            "integrity": "sha512-fGt38SsaPCZ2FmA3bX/3vOW2qdsPNx0/9x+7Aab6NMX++PhynMtK4LWC4vzXgfQBCqpUAler18H38GA+NBAd0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8149,9 +8127,9 @@
             }
         },
         "node_modules/giget": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
-            "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
             "license": "MIT",
             "bin": {
                 "giget": "dist/cli.mjs"
@@ -8320,6 +8298,15 @@
                 "node-mock-http": "^1.0.4",
                 "radix3": "^1.1.2",
                 "ufo": "^1.6.3",
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/h3/node_modules/crossws": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+            "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+            "license": "MIT",
+            "dependencies": {
                 "uncrypto": "^0.1.3"
             }
         },
@@ -8870,9 +8857,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+            "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -9375,9 +9362,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "funding": [
                 {
                     "type": "github",
@@ -9749,6 +9736,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -9768,6 +9758,9 @@
             "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -9789,6 +9782,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -9808,6 +9804,9 @@
             "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -9906,20 +9905,6 @@
             },
             "peerDependenciesMeta": {
                 "@parcel/watcher": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/listhen/node_modules/crossws": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
-            "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "srvx": ">=0.11.5"
-            },
-            "peerDependenciesMeta": {
-                "srvx": {
                     "optional": true
                 }
             }
@@ -10299,9 +10284,10 @@
             }
         },
         "node_modules/mdn-data": {
-            "version": "2.27.1",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.34.0.tgz",
+            "integrity": "sha512-OgIlLv0NxJKVW4GTSAoEgpRGd4F2XCqGinK0MsMlBCCS/Zcm2/LsbercNWNA7PeMMcjl75NnI97eqyo7zkdxWA==",
+            "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/merge-stream": {
@@ -11088,9 +11074,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.17",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -11233,6 +11219,49 @@
             "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
             "license": "MIT"
         },
+        "node_modules/nitropack/node_modules/crossws": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+            "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+            "license": "MIT",
+            "dependencies": {
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/nitropack/node_modules/db0": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
+            "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@electric-sql/pglite": "*",
+                "@libsql/client": "*",
+                "better-sqlite3": "*",
+                "drizzle-orm": "*",
+                "mysql2": "*",
+                "sqlite3": "*"
+            },
+            "peerDependenciesMeta": {
+                "@electric-sql/pglite": {
+                    "optional": true
+                },
+                "@libsql/client": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "drizzle-orm": {
+                    "optional": true
+                },
+                "mysql2": {
+                    "optional": true
+                },
+                "sqlite3": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/nitropack/node_modules/escape-string-regexp": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -11243,6 +11272,42 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nitropack/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/nitropack/node_modules/unctx": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+            "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21",
+                "unplugin": "^2.3.11"
+            }
+        },
+        "node_modules/nitropack/node_modules/unplugin": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "acorn": "^8.15.0",
+                "picomatch": "^4.0.3",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": ">=18.12.0"
             }
         },
         "node_modules/node-addon-api": {
@@ -11316,9 +11381,9 @@
             }
         },
         "node_modules/node-mock-http": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
-            "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+            "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
             "license": "MIT"
         },
         "node_modules/node-releases": {
@@ -11512,37 +11577,6 @@
                 "nuxt-component-meta": "bin/nuxt-component-meta.mjs"
             }
         },
-        "node_modules/nuxt-component-meta/node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/nuxt-component-meta/node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/nuxt-component-meta/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/nuxt-component-meta/node_modules/@oxc-parser/binding-android-arm-eabi": {
             "version": "0.139.0",
             "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.139.0.tgz",
@@ -11662,6 +11696,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -11677,6 +11714,9 @@
             "integrity": "sha512-u9e884ChAVRmIZ1jr/m46S96FoDQnruFjISLi4Y0i6Wu/JUUmIiw7+umLyXILJsPfUuqnN5BJLe23t07+Y6+IA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -11694,6 +11734,9 @@
             "cpu": [
                 "ppc64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -11709,6 +11752,9 @@
             "integrity": "sha512-RyUbr7hzPK84YDWKs77PRYk9VBwWbsbuYsQzQWiSmLnARXTg2zntLPGfCH/1wpfUYdmGkp/6SsqTXSsYdw9Jgw==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -11726,6 +11772,9 @@
             "cpu": [
                 "riscv64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -11741,6 +11790,9 @@
             "integrity": "sha512-iuGrxysV4rGUymdKpn7bgZQ6Vix8Bi/6D/rp71HYIzphq6NKrsBhsGOYsSZte+uBFL43tXh7Xr7TM72sGliJNA==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -11758,6 +11810,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -11773,6 +11828,9 @@
             "integrity": "sha512-ePxBvvtzISmSsJ0RIj8FNikSCn58i1jtccj7XR4U9Li4iSzhkFyYlnJ51cQTUwkairz8WMTD4SpKoot8RyTnQA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -11795,24 +11853,6 @@
             "os": [
                 "openharmony"
             ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/nuxt-component-meta/node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.139.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.139.0.tgz",
-            "integrity": "sha512-rNU0pO+/CVPC2qZ+xtX5R2cOje9Q75q3UkfgwUCPlplqxMv6Iffd5tMPGVMCLGnPINxPlmi0WPsW94HltbYvfQ==",
-            "cpu": [
-                "wasm32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
-                "@napi-rs/wasm-runtime": "^1.1.6"
-            },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
@@ -11863,15 +11903,6 @@
             ],
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/nuxt-component-meta/node_modules/@oxc-project/types": {
-            "version": "0.139.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/nuxt-component-meta/node_modules/oxc-parser": {
@@ -12015,38 +12046,12 @@
             "license": "MIT"
         },
         "node_modules/nuxt/node_modules/magic-string": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
-            "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+            "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
-            }
-        },
-        "node_modules/nuxt/node_modules/unctx": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "magic-string": ">=0.30.21",
-                "oxc-parser": ">=0.140.0",
-                "rolldown": "^1.1.5",
-                "unplugin": "^3.3.0"
-            },
-            "peerDependenciesMeta": {
-                "magic-string": {
-                    "optional": true
-                },
-                "oxc-parser": {
-                    "optional": true
-                },
-                "rolldown": {
-                    "optional": true
-                },
-                "unplugin": {
-                    "optional": true
-                }
             }
         },
         "node_modules/nuxtseo-shared": {
@@ -12617,9 +12622,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -12638,15 +12643,21 @@
             }
         },
         "node_modules/pkg-types": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.3.tgz",
+            "integrity": "sha512-j/lCFdcppV0JxWpCEITdbDltBxPP6cHT+yNJ6Go2OgoSA9518X847X9z0p6LtA4Nc16+eQzCZjRrWanTGvHJ5w==",
             "license": "MIT",
             "dependencies": {
-                "confbox": "^0.2.4",
-                "exsolve": "^1.0.8",
+                "confbox": "^0.3.1",
+                "exsolve": "^1.1.1",
                 "pathe": "^2.0.3"
             }
+        },
+        "node_modules/pkg-types/node_modules/confbox": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+            "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+            "license": "MIT"
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
@@ -12668,9 +12679,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.26",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+            "version": "8.5.28",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+            "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -12687,7 +12698,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.17",
+                "nanoid": "^3.3.18",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -13128,9 +13139,9 @@
             "license": "MIT"
         },
         "node_modules/powershell-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+            "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -13403,12 +13414,12 @@
             }
         },
         "node_modules/rc9": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
-            "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.1.0.tgz",
+            "integrity": "sha512-ufjkNVzbRHKcCOmTahZkmVsyc3W+MSk3jY03m+a7tGHkIsdVMG9l10/3HvFbWkkKzY5VFp3pkRsIo/UYgmFL7Q==",
             "license": "MIT",
             "dependencies": {
-                "defu": "^6.1.6",
+                "defu": "^6.1.7",
                 "destr": "^2.0.5"
             }
         },
@@ -13465,9 +13476,9 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+            "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -13853,12 +13864,12 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-            "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+            "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.143.0",
+                "@oxc-project/types": "=0.148.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -13868,20 +13879,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.2.3",
-                "@rolldown/binding-darwin-arm64": "1.2.3",
-                "@rolldown/binding-darwin-x64": "1.2.3",
-                "@rolldown/binding-freebsd-x64": "1.2.3",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-                "@rolldown/binding-linux-arm64-gnu": "1.2.3",
-                "@rolldown/binding-linux-arm64-musl": "1.2.3",
-                "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-                "@rolldown/binding-linux-s390x-gnu": "1.2.3",
-                "@rolldown/binding-linux-x64-gnu": "1.2.3",
-                "@rolldown/binding-linux-x64-musl": "1.2.3",
-                "@rolldown/binding-openharmony-arm64": "1.2.3",
-                "@rolldown/binding-win32-arm64-msvc": "1.2.3",
-                "@rolldown/binding-win32-x64-msvc": "1.2.3"
+                "@rolldown/binding-android-arm-eabi": "1.2.7",
+                "@rolldown/binding-android-arm64": "1.2.7",
+                "@rolldown/binding-darwin-arm64": "1.2.7",
+                "@rolldown/binding-darwin-x64": "1.2.7",
+                "@rolldown/binding-freebsd-x64": "1.2.7",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+                "@rolldown/binding-linux-arm64-musl": "1.2.7",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+                "@rolldown/binding-linux-x64-gnu": "1.2.7",
+                "@rolldown/binding-linux-x64-musl": "1.2.7",
+                "@rolldown/binding-openharmony-arm64": "1.2.7",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+                "@rolldown/binding-win32-x64-msvc": "1.2.7"
             }
         },
         "node_modules/rolldown-string": {
@@ -13917,18 +13929,18 @@
             }
         },
         "node_modules/rolldown/node_modules/@oxc-project/types": {
-            "version": "0.143.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+            "version": "0.148.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+            "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
             "license": "MIT",
             "funding": {
-                "url": "https://github.com/sponsors/Boshen"
+                "url": "https://github.com/sponsors/oxc-project"
             }
         },
         "node_modules/rollup": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+            "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.9"
@@ -13941,31 +13953,32 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.62.2",
-                "@rollup/rollup-android-arm64": "4.62.2",
-                "@rollup/rollup-darwin-arm64": "4.62.2",
-                "@rollup/rollup-darwin-x64": "4.62.2",
-                "@rollup/rollup-freebsd-arm64": "4.62.2",
-                "@rollup/rollup-freebsd-x64": "4.62.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-                "@rollup/rollup-linux-arm64-musl": "4.62.2",
-                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-                "@rollup/rollup-linux-loong64-musl": "4.62.2",
-                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-musl": "4.62.2",
-                "@rollup/rollup-openbsd-x64": "4.62.2",
-                "@rollup/rollup-openharmony-arm64": "4.62.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-                "@rollup/rollup-win32-x64-gnu": "4.62.2",
-                "@rollup/rollup-win32-x64-msvc": "4.62.2",
+                "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+                "@rollup/rollup-android-arm-eabi": "4.63.1",
+                "@rollup/rollup-android-arm64": "4.63.1",
+                "@rollup/rollup-darwin-arm64": "4.63.1",
+                "@rollup/rollup-darwin-x64": "4.63.1",
+                "@rollup/rollup-freebsd-arm64": "4.63.1",
+                "@rollup/rollup-freebsd-x64": "4.63.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+                "@rollup/rollup-linux-arm64-musl": "4.63.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+                "@rollup/rollup-linux-loong64-musl": "4.63.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+                "@rollup/rollup-linux-x64-gnu": "4.63.1",
+                "@rollup/rollup-linux-x64-musl": "4.63.1",
+                "@rollup/rollup-openbsd-x64": "4.63.1",
+                "@rollup/rollup-openharmony-arm64": "4.63.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+                "@rollup/rollup-win32-x64-gnu": "4.63.1",
+                "@rollup/rollup-win32-x64-msvc": "4.63.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -13999,21 +14012,6 @@
                 }
             }
         },
-        "node_modules/rollup-plugin-visualizer/node_modules/is-wsl": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-inside-container": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/rollup-plugin-visualizer/node_modules/open": {
             "version": "11.0.2",
             "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
@@ -14034,18 +14032,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/rollup-plugin-visualizer/node_modules/powershell-utils": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
-            "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0.tgz",
@@ -14053,34 +14039,6 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">= 12"
-            }
-        },
-        "node_modules/rollup-plugin-visualizer/node_modules/wsl-utils": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
-            "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
-            "license": "MIT",
-            "dependencies": {
-                "is-wsl": "^3.1.0",
-                "powershell-utils": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rollup-plugin-visualizer/node_modules/wsl-utils/node_modules/powershell-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/rou3": {
@@ -14222,9 +14180,9 @@
             }
         },
         "node_modules/seroval": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.4.tgz",
-            "integrity": "sha512-LErWMNS2RRFdu2RMA5u/PA59/IWs0XsikyEXGQ2/36iEWFrdG0ABmg17E17cikrv76891kOAMq3TkTFXpwAHXw==",
+            "version": "1.6.5",
+            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.5.tgz",
+            "integrity": "sha512-sNG8dL93a6zoDfB/+fw8d6Ovg01ydncHmPefPS54oS/3lk96EAFFWBcH79NrrHuP3Zzcb/w1lXZ5jfRabL2lHw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -15005,9 +14963,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.49.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+            "version": "5.51.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+            "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -15069,9 +15027,9 @@
             }
         },
         "node_modules/tinyexec": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+            "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -15295,54 +15253,44 @@
             "license": "MIT"
         },
         "node_modules/unctx": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
-            "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.1.tgz",
+            "integrity": "sha512-5RAt2etv7g362RXyd33R82gm9u/kbtQlpoaOs9Bgm4E32GRMJ0xjbZyvdxUTmiuHk3V1IQb1aUNrp5IWY+JaWw==",
             "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.21",
-                "unplugin": "^2.3.11"
-            }
-        },
-        "node_modules/unctx/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/unctx/node_modules/unplugin": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "acorn": "^8.15.0",
-                "picomatch": "^4.0.3",
-                "webpack-virtual-modules": "^0.6.2"
+            "peerDependencies": {
+                "magic-string": ">=0.30.21",
+                "oxc-parser": ">=0.140.0",
+                "rolldown": "^1.1.5",
+                "unplugin": "^3.3.0"
             },
-            "engines": {
-                "node": ">=18.12.0"
+            "peerDependenciesMeta": {
+                "magic-string": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "unplugin": {
+                    "optional": true
+                }
             }
         },
         "node_modules/undici": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+            "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=22.19.0"
             }
         },
         "node_modules/undici-types": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+            "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -15481,9 +15429,9 @@
             }
         },
         "node_modules/unimport/node_modules/magic-string": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
-            "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+            "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -15665,9 +15613,9 @@
             }
         },
         "node_modules/unrouting": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/unrouting/-/unrouting-0.2.2.tgz",
-            "integrity": "sha512-EoCab68s1o9AWFq9fjKsMEsmjKrPO11SAsvopikks2eEm/KLXgZMCof4cgpVgdy0Vz71OFBJw6DoDqu1oOSFGw==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/unrouting/-/unrouting-0.2.3.tgz",
+            "integrity": "sha512-8wOFT/fBh8YeeDr1aVmkXCqYVTMbQ6vzfNzwzybKmSfXdRhGCq1Y2B1e9YeB0JEf85gbvSwJHAMu3D2IEcLGKA==",
             "license": "MIT",
             "dependencies": {
                 "escape-string-regexp": "^5.0.0",
@@ -15984,15 +15932,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-            "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+            "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.33.0",
                 "picomatch": "^4.0.5",
-                "postcss": "^8.5.25",
-                "rolldown": "~1.2.1",
+                "postcss": "^8.5.26",
+                "rolldown": "~1.2.4",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -16009,7 +15957,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.4.0",
+                "@vitejs/devtools": "^0.4.0 || ^0.5.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -16234,17 +16182,17 @@
             }
         },
         "node_modules/vite-plugin-inspect/node_modules/open": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+            "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
             "license": "MIT",
             "dependencies": {
-                "default-browser": "^5.4.0",
+                "default-browser": "^5.5.1",
                 "define-lazy-prop": "^3.0.0",
                 "is-in-ssh": "^1.0.0",
                 "is-inside-container": "^1.0.0",
-                "powershell-utils": "^0.1.0",
-                "wsl-utils": "^0.3.0"
+                "powershell-utils": "^0.2.1",
+                "wsl-utils": "^1.0.0"
             },
             "engines": {
                 "node": ">=20"
@@ -16254,14 +16202,14 @@
             }
         },
         "node_modules/vite-plugin-vue-tracer": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-vue-tracer/-/vite-plugin-vue-tracer-1.4.0.tgz",
-            "integrity": "sha512-0tQCjCqZWVSK6UeRW9S4ABbf47lKQ68zvrT2FNvZmiL+alDydCVyH/T3Jlfbdc3T3C2Iuyyl5aVsMbF8IQIoxA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-vue-tracer/-/vite-plugin-vue-tracer-1.5.0.tgz",
+            "integrity": "sha512-G2aQ676fLBPnYhRi5lsARoL4hbtc/sx6fVzO7p44AB+1xQXo2UuiRgv7K26UdijrNzmuQprmJ121n3rdjBk1CA==",
             "license": "MIT",
             "dependencies": {
                 "estree-walker": "^3.0.3",
-                "exsolve": "^1.0.8",
-                "magic-string": "^0.30.21",
+                "exsolve": "^1.1.1",
+                "magic-string": "^1.1.0",
                 "pathe": "^2.0.3",
                 "source-map-js": "^1.2.1"
             },
@@ -16280,6 +16228,15 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/vite-plugin-vue-tracer/node_modules/magic-string": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+            "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/vite/node_modules/lightningcss": {
@@ -16418,6 +16375,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -16437,6 +16397,9 @@
             "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -16458,6 +16421,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -16477,6 +16443,9 @@
             "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -16532,9 +16501,9 @@
             }
         },
         "node_modules/vscode-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+            "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
             "license": "MIT"
         },
         "node_modules/vue": {
@@ -16568,13 +16537,13 @@
             }
         },
         "node_modules/vue-component-meta": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.3.9.tgz",
-            "integrity": "sha512-4u1VmMVjqs9BbKaISBZD7b+dNdqFteh5BYN8xVaXkjjJ66no1sRtDnS6aSs5/P5AzQQGPw10snHTf/z3HpBn2w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.3.11.tgz",
+            "integrity": "sha512-fskQZaIFOifwB4x+/J24795yvezOJ1TKaqn97/4PHybyvXpDNdcKn3oTcPrw6HnNoZWe343A+TiCFOcFv1/SuQ==",
             "license": "MIT",
             "dependencies": {
                 "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.3.9",
+                "@vue/language-core": "3.3.11",
                 "path-browserify": "^1.0.1"
             },
             "peerDependencies": {
@@ -16685,22 +16654,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=5.0.0"
-            }
-        },
-        "node_modules/vue-tsc/node_modules/@vue/language-core": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.11.tgz",
-            "integrity": "sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/language-core": "2.4.28",
-                "@vue/compiler-dom": "^3.5.0",
-                "@vue/shared": "^3.5.0",
-                "alien-signals": "^3.2.1",
-                "muggle-string": "^0.4.1",
-                "path-browserify": "^1.0.1",
-                "picomatch": "^4.0.4"
             }
         },
         "node_modules/web-namespaces": {
@@ -16900,9 +16853,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.21.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-            "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -16921,9 +16874,9 @@
             }
         },
         "node_modules/wsl-utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+            "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
             "license": "MIT",
             "dependencies": {
                 "is-wsl": "^3.1.0",
@@ -16946,6 +16899,18 @@
             },
             "engines": {
                 "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -38,9 +38,8 @@
         "vue-tsc": "^3.3.11"
     },
     "allowScripts": {
-        "esbuild@0.28.1": true,
+        "esbuild@0.28.2": true,
         "unrs-resolver@1.12.2": true,
-        "@parcel/watcher@2.5.6": true,
         "better-sqlite3@13.0.3": true
     }
 }


### PR DESCRIPTION
Regenerates the npm lockfile from scratch under Node.js 26.8.1 so the project uses current transitive releases allowed by its existing dependency constraints.

- Refresh 118 locked package versions, including the Nanoid 3.3.18 security fix from #106.
- Re-resolve and deduplicate the dependency graph without widening direct dependency ranges.
- Update the esbuild install-script approval and remove the obsolete Parcel watcher approval.